### PR TITLE
fix logger level

### DIFF
--- a/deoldify/__init__.py
+++ b/deoldify/__init__.py
@@ -1,7 +1,14 @@
 import sys
 import logging
-logging.getLogger().addHandler(logging.StreamHandler(sys.stdout))
-logging.getLogger().setLevel(logging.INFO)
+try:
+    import modules.shared
+    IS_INSIDE_WEBUI = True
+except ImportError:
+    IS_INSIDE_WEBUI = False
+
+if not IS_INSIDE_WEBUI:
+    logging.getLogger().addHandler(logging.StreamHandler(sys.stdout))
+    logging.getLogger().setLevel(logging.INFO)
 
 from deoldify._device import _Device
 


### PR DESCRIPTION
While making this [PR](https://github.com/AUTOMATIC1111/stable-diffusion-webui/pull/15210) in webui I found out deoldify overrides global loglevel inside `__init__.py` 